### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Push to R2
+permissions:
+  contents: read
 on: 
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/sappho192/ffxiv-hermes/security/code-scanning/1](https://github.com/sappho192/ffxiv-hermes/security/code-scanning/1)

To fix this problem, the workflow should explicitly set the `permissions` block to restrict GITHUB_TOKEN access to only what is needed. In this specific workflow, the steps do not seem to require any special write permissions to the repo or PRs, so the least privilege setting is `contents: read`. This can be set either at the workflow root (to apply to all jobs) or under the `build` job. The best practice is to set it at the workflow root for global least-privilege. The change consists of adding:

```yaml
permissions:
  contents: read
```

right after the `name:` and before the `on:` section in `.github/workflows/main.yml`. No imports or code refactoring is necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
